### PR TITLE
_fetchTables recursive must match signature

### DIFF
--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -166,11 +166,11 @@ DynamoBackup.prototype._fetchTables = function(lastTable, tables, callback) {
         }
         tables = tables.concat(data.TableNames);
         if (data.LastEvaluatedTableName) {
-            self._fetchTables(data.LastEvaluatedTableName, callback);
+            self._fetchTables(data.LastEvaluatedTableName, tables, callback);
         } else {
             callback(null, tables);
         }
     });
-}
+};
 
 module.exports = DynamoBackup;


### PR DESCRIPTION
This recursive call to _fetchTables recursively adds to the list of tables, and I think the second parameter should be the list.