### PR TITLE
Base64 encoding binary field data before saving to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Can be run as a command line script or as an npm module.
     -x, --excluded-tables <list>     exclude these tables from backup
     -i, --included-tables <list>     only backup these tables
     -p, --backup-path <name>         backup path to store table dumps in. default is DynamoDB-backup-YYYY-MM-DD-HH-mm-ss
+    -e, --base64-encode-binary       if passed, encode binary fields in base64 before exporting
     --aws-key                        AWS access key. Will use AWS_ACCESS_KEY_ID env var if --aws-key not set
     --aws-secret                     AWS secret key. Will use AWS_SECRET_ACCESS_KEY env var if --aws-secret not set
     --aws-region                     AWS region. Will use AWS_DEFAULT_REGION env var if --aws-region not set
@@ -38,6 +39,7 @@ var backup = new DynamoBackup({
     readPercentage: .5,
     bucket: 'my-backups',
     stopOnFailure: true,
+    base64Binary: true,
     awsAccessKey: /* AWS access key */,
     awsSecretKey: /* AWS secret key */,
     awsSecretKey: /* AWS region */
@@ -77,7 +79,8 @@ var options = {
     awsAccessKey:   /* AWS access key */,
     awsSecretKey:   /* AWS secret key */,
     awsSecretKey:   /* AWS region */,
-    backupPath:     /* folder to save backups in.  default: 'DynamoDB-backup-YYYY-MM-DD-HH-mm-ss'
+    backupPath:     /* folder to save backups in.  default: 'DynamoDB-backup-YYYY-MM-DD-HH-mm-ss',
+    base64Binary:   /* whether or not to base64 encode binary data before saving to JSON */
 };
 
 var backup = new DynamoBackup(options);

--- a/bin/dynamo-backup-to-s3
+++ b/bin/dynamo-backup-to-s3
@@ -24,6 +24,7 @@ program
     .option('-x, --excluded-tables <list>', 'exclude these tables from backup', list)
     .option('-i, --included-tables <list>', 'only backup these tables', list)
     .option('-p, --backup-path <name>', 'backup path to store table dumps in. default is DynamoDB-backup-YYYY-MM-DD-HH-mm-ss')
+    .option('-e, --base64-encode-binary', 'encode binary fields in base64 before exporting')
     .option('--aws-key', 'AWS access key. Will use AWS_ACCESS_KEY_ID env var if --aws-key not set')
     .option('--aws-secret', 'AWS secret key. Will use AWS_SECRET_ACCESS_KEY env var if --aws-secret not set')
     .option('--aws-region', 'AWS region. Will use AWS_DEFAULT_REGION env var if --aws-region not set')
@@ -42,7 +43,8 @@ var dynamoBackup = new DynamoBackup({
     excludedTables: program.excludedTables,
     includedTables: program.includedTables,
     readPercentage: program.readPercentage,
-    stopOnFailure: program.stopOnFailure
+    stopOnFailure: program.stopOnFailure,
+    base64Binary: program.base64EncodeBinary
 });
 
 dynamoBackup.on('error', function(data) {

--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -19,7 +19,7 @@ function DynamoBackup(options) {
     this.backupPath = options.backupPath;
     this.bucket = options.bucket;
     this.stopOnFailure = options.stopOnFailure || false;
-    this.base64Binary = options.base64EncodeBinary || false;
+    this.base64Binary = options.base64Binary || false;
     this.awsAccessKey = options.awsAccessKey || process.env.AWS_ACCESS_KEY_ID;
     this.awsSecretKey = options.awsSecretKey || process.env.AWS_SECRET_ACCESS_KEY;
     this.awsRegion = options.awsRegion || process.env.AWS_DEFAULT_REGION || 'us-east-1';

--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -19,6 +19,7 @@ function DynamoBackup(options) {
     this.backupPath = options.backupPath;
     this.bucket = options.bucket;
     this.stopOnFailure = options.stopOnFailure || false;
+    this.base64Binary = options.base64EncodeBinary || false;
     this.awsAccessKey = options.awsAccessKey || process.env.AWS_ACCESS_KEY_ID;
     this.awsSecretKey = options.awsSecretKey || process.env.AWS_SECRET_ACCESS_KEY;
     this.awsRegion = options.awsRegion || process.env.AWS_DEFAULT_REGION || 'us-east-1';
@@ -71,11 +72,13 @@ DynamoBackup.prototype.backupTable = function (tableName, backupPath, callback) 
         tableName,
         function(items) {
             items.forEach(function(item) {
-                _.each(item, function (value, key) {
-                    if (value && value.B) {
-                        value.B = new Buffer(value.B).toString('base64');
-                    }
-                });
+                if (self.base64Binary) {
+                    _.each(item, function (value, key) {
+                        if (value && value.B) {
+                            value.B = new Buffer(value.B).toString('base64');
+                        }
+                    });
+                }
                 stream.append(JSON.stringify(item));
                 stream.append('\n');
             });

--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -71,6 +71,11 @@ DynamoBackup.prototype.backupTable = function (tableName, backupPath, callback) 
         tableName,
         function(items) {
             items.forEach(function(item) {
+                _.each(item, function (value, key) {
+                    if (value && value.B) {
+                        value.B = new Buffer(value.B).toString('base64');
+                    }
+                });
                 stream.append(JSON.stringify(item));
                 stream.append('\n');
             });


### PR DESCRIPTION
We store some data in binary fields in Dynamo which can't be backed up as-is to JSON. This small change just base64 encodes binary fields before saving as JSON.