### PR TITLE
fixed access issue from lambda via IAM role temp creds

### DIFF
--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -26,11 +26,16 @@ function DynamoBackup(options) {
     this.awsRegion = options.awsRegion || process.env.AWS_DEFAULT_REGION || 'us-east-1';
     this.debug = Boolean(options.debug);
 
-    AWS.config.update({
-        accessKeyId: this.awsAccessKey,
-        secretAccessKey: this.secretAccessKey,
-        region: this.awsRegion
-    });
+    // ensure that temporary credentials from IAM role don't get
+    // passed in as user access key without session token
+    if (this.awsAccessKey !== undefined &&
+        this.awsAccessKey.lastIndexOf('AKIA', 0) === 0) {
+        AWS.config.update({
+            accessKeyId: this.awsAccessKey,
+            secretAccessKey: this.secretAccessKey,
+            region: this.awsRegion
+        });
+    }
 }
 
 util.inherits(DynamoBackup, events.EventEmitter);
@@ -49,15 +54,21 @@ DynamoBackup.prototype.backupTable = function (tableName, backupPath, callback) 
         backupPath = self._getBackupPath();
     }
 
-    var upload = new Uploader({
-        accessKey: self.awsAccessKey,
-        secretKey: self.awsSecretKey,
-        region: self.awsRegion,
+    var uploaderParams = {
         bucket: self.bucket,
         objectName: path.join(backupPath, tableName + '.json'),
         stream: stream,
         debug: self.debug
-    });
+    }
+
+    if (self.awsAccessKey !== undefined &&
+        self.awsAccessKey.lastIndexOf('AKIA', 0) === 0) {
+        uploaderParams.accessKey = self.awsAccessKey;
+        uploaderParams.secretKey = self.awsSecretKey;
+        uploaderParams.region = self.awsRegion;
+    }
+
+    var upload = new Uploader(uploaderParams);
 
     var startTime = moment.utc();
     self.emit('start-backup', tableName, startTime);


### PR DESCRIPTION
I tried running this from AWS Lambda using an IAM role and AWS.config.update throws an InvalidAccessKeyId exception saying "The AWS Access Key Id you provided does not exist in our records.".  Apparently when running in the Lambda environment using an IAM role, the AWS_ACCESS_KEY_ID environment variable has an accesss key starting with ASIA rather than the usual AKIA.  I made it skip the AWS.config.update when it appears to be picking up temporary creds from the system environment variables and it is now working both locally in Ubuntu and from within Lambda.