### PR TITLE
When the -d option is used, for Maps and Lists, the keys of individual items are now converted to lower case.

### DIFF
--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -234,8 +234,9 @@ DynamoBackup.prototype._getDataPipelineAttributeValueKey = function (type) {
         case 'M':
         case 'L':
         case 'NULL':
-        case 'BOOL':
             return type.toLowerCase();
+        case 'BOOL':
+            return 'bOOL';
         case 'SS':
             return 'sS';
         case 'NS':

--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -38,7 +38,7 @@ util.inherits(DynamoBackup, events.EventEmitter);
 DynamoBackup.prototype.listTables = function (callback) {
     var self = this;
     self._fetchTables(null, [], callback);
-}
+};
 
 DynamoBackup.prototype.backupTable = function (tableName, backupPath, callback) {
     var self = this;
@@ -104,7 +104,7 @@ DynamoBackup.prototype.backupTable = function (tableName, backupPath, callback) 
             }
         }
         );
-}
+};
 
 DynamoBackup.prototype.backupAllTables = function (callback) {
     var self = this;
@@ -132,13 +132,13 @@ DynamoBackup.prototype.backupAllTables = function (callback) {
             callback
             );
     });
-}
+};
 
 DynamoBackup.prototype._getBackupPath = function () {
     var self = this;
     var now = moment.utc();
     return self.backupPath || ('DynamoDB-backup-' + now.format('YYYY-MM-DD-HH-mm-ss'));
-}
+};
 
 DynamoBackup.prototype._copyTable = function (tableName, itemsReceived, callback) {
     var self = this;
@@ -153,7 +153,7 @@ DynamoBackup.prototype._copyTable = function (tableName, itemsReceived, callback
 
         self._streamItems(tableName, null, limit, itemsReceived, callback);
     });
-}
+};
 
 DynamoBackup.prototype._streamItems = function fetchItems(tableName, startKey, limit, itemsReceived, callback) {
     var self = this;
@@ -180,7 +180,7 @@ DynamoBackup.prototype._streamItems = function fetchItems(tableName, startKey, l
         }
         self._streamItems(tableName, data.LastEvaluatedKey, limit, itemsReceived, callback);
     });
-}
+};
 
 DynamoBackup.prototype._fetchTables = function (lastTable, tables, callback) {
     var self = this;
@@ -217,6 +217,10 @@ DynamoBackup.prototype._formatForDataPipeline = function (item) {
             var dataPipelineValueKey = self._getDataPipelineAttributeValueKey(k);
             value[dataPipelineValueKey] = v;
             value[k] = undefined;
+            // for MAps and Lists, recurse until the elements are created with the correct case
+            if(k === 'M' || k === 'L') {
+              self._formatForDataPipeline(v);
+            }
         });
     });
     return JSON.stringify(item);
@@ -241,6 +245,6 @@ DynamoBackup.prototype._getDataPipelineAttributeValueKey = function (type) {
         default:
             throw new Error('Unknown AttributeValue key: ' + type);
     }
-}
+};
 
 module.exports = DynamoBackup;


### PR DESCRIPTION
This PR fixes a bug where keys for individual items stored in Maps and Lists did not get converted to lower case when user selects the option to save data in data pipeline format (-d). 
As a result, restoring data with Maps and Lists using the Data Pipeline does not work.