### PR TITLE
Fixes for restore `--overwrite` flag

### DIFF
--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -103,7 +103,7 @@ DynamoRestore.prototype._checkTableExists = function(error, data) {
     if (data.TableNames.indexOf(this.options.table) > -1) {
         // Table exists, should we overwrite it??
         if (this.options.overwrite) {
-            this.emit('warning', util.format('WARN: table [%s] will be overwritten.', options.table));
+            this.emit('warning', util.format('WARN: table [%s] will be overwritten.', this.options.table));
             dynamodb.describeTable({ TableName: this.options.table }, this._checkTableReady.bind(this));
         } else {
             this.emit('error', 'Fatal Error. The destination table already exists! Exiting process..');

--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -106,7 +106,7 @@ DynamoRestore.prototype._checkTableExists = function(error, data) {
         // Table exists, should we overwrite it??
         if (this.options.overwrite) {
             this.emit('warning', util.format('WARN: table [%s] will be overwritten.', this.options.table));
-            setTimeout(dynamodb.describeTable.bind(dynamodb, { TableName: this.options.table }, this._checkTableReady.bind(this), 1000);
+            setTimeout(dynamodb.describeTable.bind(dynamodb, { TableName: this.options.table }, this._checkTableReady.bind(this)), 1000);
         } else {
             this.emit('error', 'Fatal Error. The destination table already exists! Exiting process..');
         }

--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -98,6 +98,7 @@ DynamoRestore.prototype._validateTable = function(options) {
 };
 
 DynamoRestore.prototype._checkTableExists = function(error, data) {
+    var dynamodb = this.dynamodb;
     if (error || !data || !data.TableNames) {
         return this.emit('error', 'Fatal Error. Could not connect to AWS DynamoDB engine. Please check your credentials.');
     }
@@ -105,7 +106,7 @@ DynamoRestore.prototype._checkTableExists = function(error, data) {
         // Table exists, should we overwrite it??
         if (this.options.overwrite) {
             this.emit('warning', util.format('WARN: table [%s] will be overwritten.', this.options.table));
-            this.dynamodb.describeTable({ TableName: this.options.table }, this._checkTableReady.bind(this));
+            setTimeout(dynamodb.describeTable.bind(dynamodb, { TableName: this.options.table }, this._checkTableReady.bind(this), 1000);
         } else {
             this.emit('error', 'Fatal Error. The destination table already exists! Exiting process..');
         }

--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -315,7 +315,7 @@ DynamoRestore.prototype._sendBatch = function() {
         var unprocessedItems = data && data.UnprocessedItems && data.UnprocessedItems[options.table] || [];
         if (unprocessedItems.length) {
             // Retry unprocessed items
-            this.emit('warning', 'Retrying ' + unprocessedItems.length + ' unprocessed items');
+            this.emit('warning', unprocessedItems.length + ' unprocessed items. Add to queue and back off a bit.');
             this.batches.push({
                 items: unprocessedItems,
                 attempts: batch.attempts + 1

--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -32,6 +32,7 @@ function DynamoRestore(options) {
     });
 
     this.options = options;
+    this.dynamodb = new AWS.DynamoDB();
 }
 
 // Stick to prototypal inheritance. While this can be done differently 
@@ -53,7 +54,7 @@ DynamoRestore.prototype.run = function(finishCallback) {
     }).bind(this));
     // Finish off by updating write capacity to end-state (if needed)
     this.on('finish', (function() {
-        var dynamodb = new AWS.DynamoDB(),
+        var dynamodb = this.dynamodb,
             options = this.options;
         // Do we need to update write capacity?
         if (options.writecapacity) {
@@ -89,7 +90,7 @@ DynamoRestore.prototype._validateS3Backup = function(options) {
 };
 
 DynamoRestore.prototype._validateTable = function(options) {
-    var dynamodb = new AWS.DynamoDB();
+    var dynamodb = this.dynamodb;
     if (!options.table) {
         return this.emit('error', 'Please provide a Dynamo DB table name to restore to.');
     }
@@ -104,7 +105,7 @@ DynamoRestore.prototype._checkTableExists = function(error, data) {
         // Table exists, should we overwrite it??
         if (this.options.overwrite) {
             this.emit('warning', util.format('WARN: table [%s] will be overwritten.', this.options.table));
-            dynamodb.describeTable({ TableName: this.options.table }, this._checkTableReady.bind(this));
+            this.dynamodb.describeTable({ TableName: this.options.table }, this._checkTableReady.bind(this));
         } else {
             this.emit('error', 'Fatal Error. The destination table already exists! Exiting process..');
         }
@@ -228,7 +229,7 @@ DynamoRestore.prototype._extractSchema = function(template) {
 };
 
 DynamoRestore.prototype._createTable = function(callback) {
-    var dynamodb = new AWS.DynamoDB(),
+    var dynamodb = this.dynamodb,
         options = this.options;
     if (!options.table || !options.partitionkey) {
         return this.emit('error', 'Fatal Error. Could not create dynamo table. Not enough information provided.');
@@ -269,7 +270,7 @@ DynamoRestore.prototype._createTable = function(callback) {
 };
 
 DynamoRestore.prototype._checkTableReady = function(error, data) {
-    var dynamodb = new AWS.DynamoDB();
+    var dynamodb = this.dynamodb;
     if (error || !data || !data.Table) {
         return this.emit('error', 'Error creating table ' + this.options.table);
     }
@@ -288,7 +289,7 @@ DynamoRestore.prototype._checkTableReady = function(error, data) {
 DynamoRestore.prototype._sendBatch = function() {
     // Prepare
     var params = { RequestItems: {} },
-        dynamo = new AWS.DynamoDB(),
+        dynamo = this.dynamodb,
         options = this.options;
     batch = this.batches.shift();
     params.RequestItems[options.table] = batch.items;


### PR DESCRIPTION
Hi Dylan, Sorry I hadn't got around to testing the new `--overwrite` flag when this was merged. 

The purpose of the flag is to allow more control over timing and table creation, and may be preferred in many circumstances where table schema has been defined by preexisting CLI script and/or cloudformation.

This is now tested and working. Here are some changes to support it. 