### PR TITLE
Fixed null reference

### DIFF
--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -103,7 +103,7 @@ DynamoRestore.prototype._checkTableExists = function(error, data) {
     if (data.TableNames.indexOf(this.options.table) > -1) {
         // Table exists, should we overwrite it??
         if (this.options.overwrite) {
-            this.emit('warning', util.format('WARN: table [%s] will be overwritten.', options.table));
+            this.emit('warning', util.format('WARN: table [%s] will be overwritten.', this.options.table));
             dynamodb.describeTable({ TableName: this.options.table }, this._checkTableReady.bind(this));
         } else {
             this.emit('error', 'Fatal Error. The destination table already exists! Exiting process..');

--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -100,6 +100,7 @@ DynamoRestore.prototype._checkTableExists = function(error, data) {
     if (error || !data || !data.TableNames) {
         return this.emit('error', 'Fatal Error. Could not connect to AWS DynamoDB engine. Please check your credentials.');
     }
+    var dynamodb = new AWS.DynamoDB();
     if (data.TableNames.indexOf(this.options.table) > -1) {
         // Table exists, should we overwrite it??
         if (this.options.overwrite) {

--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -105,7 +105,9 @@ DynamoRestore.prototype._checkTableExists = function(error, data) {
         // Table exists, should we overwrite it??
         if (this.options.overwrite) {
             this.emit('warning', util.format('WARN: table [%s] will be overwritten.', this.options.table));
-            dynamodb.describeTable({ TableName: this.options.table }, this._checkTableReady.bind(this));
+            setTimeout(() => {
+              dynamodb.describeTable({ TableName: this.options.table }, this._checkTableReady.bind(this));
+            }, 1000);
         } else {
             this.emit('error', 'Fatal Error. The destination table already exists! Exiting process..');
         }

--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -279,8 +279,8 @@ DynamoRestore.prototype._checkTableReady = function(error, data) {
         data.Table.TableStatus === 'ACTIVE') {
         // All ready, now we can start inserting records
         this.tableready = true;
-        this.readline.resume();
-        while (this.batches.length) { this._sendBatch(); }
+        if (this.readline) this.readline.resume();
+        while (this.batches && this.batches.length) { this._sendBatch(); }
     } else {
         setTimeout(dynamodb.describeTable.bind(dynamodb, { TableName: data.Table.TableName }, this._checkTableReady.bind(this)), 1000);
     }


### PR DESCRIPTION
Was receiving the following error when trying to overwrite an existing table.

```
ReferenceError: options is not defined
    at DynamoRestore._checkTableExists (/Users/awolde/Repos/bowerman/node_modules/dynamo-backup-to-s3/lib/dynamo-restore.js:110:87)
    at Request.<anonymous> (/Users/awolde/Repos/bowerman/node_modules/aws-sdk/lib/request.js:358:18)
    at Request.callListeners (/Users/awolde/Repos/bowerman/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/Users/awolde/Repos/bowerman/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/Users/awolde/Repos/bowerman/node_modules/aws-sdk/lib/request.js:671:14)
    at Request.transition (/Users/awolde/Repos/bowerman/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/awolde/Repos/bowerman/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/awolde/Repos/bowerman/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/Users/awolde/Repos/bowerman/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/Users/awolde/Repos/bowerman/node_modules/aws-sdk/lib/request.js:673:12)
    at Request.callListeners (/Users/awolde/Repos/bowerman/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at Request.emit (/Users/awolde/Repos/bowerman/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/Users/awolde/Repos/bowerman/node_modules/aws-sdk/lib/request.js:671:14)
    at Request.transition (/Users/awolde/Repos/bowerman/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/awolde/Repos/bowerman/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/awolde/Repos/bowerman/node_modules/aws-sdk/lib/state_machine.js:26:10
```