### PR TITLE
Fixes restore script AWS configuration

### DIFF
--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -14,6 +14,7 @@ var readline = require('readline');
 var DYNAMO_CHUNK_SIZE = 25;
 
 function DynamoRestore(options) {
+    var params = {};
     options = options || {};
     options.concurrency = options.concurrency || 200;
     options.minConcurrency = 1;
@@ -21,15 +22,20 @@ function DynamoRestore(options) {
     options.readcapacity = options.readcapacity || 5;
     options.writecapacity = options.writecapacity || 0;
     options.stopOnFailure = options.stopOnFailure || false;
-    options.awsKey = options.awsKey || process.env.AWS_ACCESS_KEY_ID;
-    options.awsSecret = options.awsSecret || process.env.AWS_SECRET_ACCESS_KEY;
-    options.awsRegion = options.awsRegion || process.env.AWS_DEFAULT_REGION || 'ap-southeast-2';
 
-    AWS.config.update({
-        accessKeyId: options.awsKey,
-        secretAccessKey: options.awsSecret,
-        region: options.awsRegion
-    });
+    if (options.awsRegion) {
+        params.region = options.awsRegion;
+    }
+    else if (!process.env.AWS_REGION) {
+        params.region = process.env.AWS_DEFAULT_REGION || 'ap-southeast-2';
+    }
+
+    if (options.awsKey && options.awsSecret) {
+        params.accessKeyId = options.awsKey;
+        params.secretAccessKey = options.awsSecret;
+    }
+
+    AWS.config.update(params);
 
     this.options = options;
     this.dynamodb = new AWS.DynamoDB();


### PR DESCRIPTION
This change removes environmental inference from the restore script, restoring the usual credential precedence established in `aws-sdk`. The default region (Sydney) is preserved for back-compatibility.

Thanks for your consideration!