### PR TITLE
Export entire contents of bin directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "s3",
     "stream"
   ],
-  "bin": {
-    "dynamo-backup-to-s3": "./bin/dynamo-backup-to-s3"
+  "directories": {
+    "bin": "./bin"
   },
   "dependencies": {
     "async": "^1.5.0",


### PR DESCRIPTION
Currently only the dynamo-backup-to-s3 tool is exported by npm to the PATH of calling modules. Using the directories.bin property, all of the scripts in the specified directory are added to PATH.