### PR TITLE
Adds support for objectParams to be passed into the DynamoBackup class

### DIFF
--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -22,6 +22,7 @@ function DynamoBackup(options) {
     this.stopOnFailure = options.stopOnFailure || false;
     this.base64Binary = options.base64Binary || false;
     this.saveDataPipelineFormat = options.saveDataPipelineFormat || false;
+    this.objectParams = options.objectParams || {};
     this.awsAccessKey = options.awsAccessKey;
     this.awsSecretKey = options.awsSecretKey;
     this.awsRegion = options.awsRegion;
@@ -65,6 +66,7 @@ DynamoBackup.prototype.backupTable = function (tableName, backupPath, callback) 
 
    params.bucket = self.bucket;
    params.objectName = path.join(backupPath, tableName + '.json');
+   params.objectParams = self.objectParams;
    params.stream = stream;
    params.debug = self.debug;
 


### PR DESCRIPTION
Adds support for objectParams to be passed into the DynamoBackup class and through to the s3-streaming-upload for use by the aws.S3.ManagedUpload object. This enables a caller to specify aws request options such as ServerSideEncryption.