### PR TITLE
Server side encryption and ACL options to S3

### DIFF
--- a/bin/dynamo-backup-to-s3
+++ b/bin/dynamo-backup-to-s3
@@ -19,6 +19,7 @@ program
     .version(JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8')).version)
     .usage('[options]')
     .option('-b, --bucket <name>', 'S3 bucket to store backups')
+    .option('-a, --acl <acl>', 'The canned ACL to apply to the object')
     .option('-s, --stop-on-failure', 'specify the reporter to use', parseBool, true)
     .option('-r, --read-percentage <decimal>', 'specific the percentage of Dynamo read capacity to use while backing up. default .25 (25%)', parseFloat, .25)
     .option('-x, --excluded-tables <list>', 'exclude these tables from backup', list)
@@ -26,6 +27,7 @@ program
     .option('-p, --backup-path <name>', 'backup path to store table dumps in. default is DynamoDB-backup-YYYY-MM-DD-HH-mm-ss')
     .option('-e, --base64-encode-binary', 'encode binary fields in base64 before exporting')
     .option('-d, --save-data-pipeline-format', 'save in format compatible with the AWS Data Pipeline import. Default to false (save as exported by DynamoDb)')
+    .option('--server-side-encryption', 'enable server side encryption on S3. either AES256 or aws:kms (disabled by default)')
     .option('--aws-key <key>', 'AWS access key. Will use AWS_ACCESS_KEY_ID env var if --aws-key not set')
     .option('--aws-secret <secret>', 'AWS secret key. Will use AWS_SECRET_ACCESS_KEY env var if --aws-secret not set')
     .option('--aws-region <region>', 'AWS region. Will use AWS_DEFAULT_REGION env var if --aws-region not set')
@@ -39,6 +41,7 @@ var dynamoBackup = new DynamoBackup({
     awsAccessKey: program.awsKey,
     awsSecretKey: program.awsSecret,
     awsRegion: program.awsRegion,
+    acl: program.acl,
     backupPath: program.backupPath,
     bucket: program.bucket,
     excludedTables: program.excludedTables,
@@ -46,7 +49,8 @@ var dynamoBackup = new DynamoBackup({
     readPercentage: program.readPercentage,
     stopOnFailure: program.stopOnFailure,
     base64Binary: program.base64EncodeBinary,
-    saveDataPipelineFormat: program.saveDataPipelineFormat
+    saveDataPipelineFormat: program.saveDataPipelineFormat,
+    serverSideEncryption: program.serverSideEncryption,
 });
 
 dynamoBackup.on('error', function(data) {

--- a/bin/dynamo-restore-from-s3
+++ b/bin/dynamo-restore-from-s3
@@ -16,6 +16,7 @@ program
     .option('-rc, --readcapacity <units>', 'Read Units for new table (when finished). Default is 5.')
     .option('-wc, --writecapacity <units>', 'Write Units for new table (when finished). Default is --concurrency.')
     .option('-sf, --stop-on-failure', 'Stop process when the same batch fails to restore 3 times. Defaults to false.', true)
+    .option('--server-side-encryption', 'enable server side encryption on S3. either AES256 or aws:kms (disabled by default)')
     .option('--aws-key <key>', 'AWS access key. Will use AWS_ACCESS_KEY_ID env var if --aws-key not set')
     .option('--aws-secret <secret>', 'AWS secret key. Will use AWS_SECRET_ACCESS_KEY env var if --aws-secret not set')
     .option('--aws-region <region>', 'AWS region. Will use AWS_DEFAULT_REGION env var if --aws-region not set')
@@ -40,6 +41,7 @@ var dynamoRestore = new DynamoRestore({
     overwrite: !!program.overwrite,
     concurrency: program.concurrency,
     stopOnFailure: !!program.stopOnFailure,
+    serverSideEncryption: program.serverSideEncryption,
     // New table properties
     partitionkey: program.partitionkey,
     sortkey: program.sortkey,

--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -22,6 +22,8 @@ function DynamoBackup(options) {
     this.stopOnFailure = options.stopOnFailure || false;
     this.base64Binary = options.base64Binary || false;
     this.saveDataPipelineFormat = options.saveDataPipelineFormat || false;
+    this.serverSideEncryption = options.serverSideEncryption || false
+    this.acl = options.acl || false;
     this.awsAccessKey = options.awsAccessKey;
     this.awsSecretKey = options.awsSecretKey;
     this.awsRegion = options.awsRegion;
@@ -54,21 +56,29 @@ DynamoBackup.prototype.backupTable = function (tableName, backupPath, callback) 
         backupPath = self._getBackupPath();
     }
 
-   var params = {};
-   if (self.awsRegion) {
-       params.region = self.awsRegion;
-   }
-   if (self.awsAccessKey && self.awsSecretKey) {
+    var params = {
+        objectParams: {}
+    };
+    if (self.awsRegion) {
+        params.region = self.awsRegion;
+    }
+    if (self.awsAccessKey && self.awsSecretKey) {
         params.accessKey = self.awsAccessKey;
         params.secretKey = self.awsSecretKey;
     }
+    if (self.serverSideEncryption) {
+        params.objectParams.ServerSideEncryption = self.serverSideEncryption
+    }
+    if (self.acl) {
+        params.objectParams.ACL = self.acl
+    }
 
-   params.bucket = self.bucket;
-   params.objectName = path.join(backupPath, tableName + '.json');
-   params.stream = stream;
-   params.debug = self.debug;
+    params.bucket = self.bucket;
+    params.objectName = path.join(backupPath, tableName + '.json');
+    params.stream = stream;
+    params.debug = self.debug;
 
-   var upload = new Uploader(params);
+    var upload = new Uploader(params);
 
     var startTime = moment.utc();
     self.emit('start-backup', tableName, startTime);

--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -21,6 +21,7 @@ function DynamoRestore(options) {
     options.readcapacity = options.readcapacity || 5;
     options.writecapacity = options.writecapacity || 0;
     options.stopOnFailure = options.stopOnFailure || false;
+    options.serverSideEncryption = options.serverSideEncryption || false;
     options.awsKey = options.awsKey || process.env.AWS_ACCESS_KEY_ID;
     options.awsSecret = options.awsSecret || process.env.AWS_SECRET_ACCESS_KEY;
     options.awsRegion = options.awsRegion || process.env.AWS_DEFAULT_REGION || 'ap-southeast-2';
@@ -127,6 +128,9 @@ DynamoRestore.prototype._startDownload = function() {
         Bucket: this.options.s3bucket,
         Key: this.options.s3path
     };
+    if (this.options.serverSideEncryption) {
+       params.ServerSideEncryption = this.options.serverSideEncryption;
+    }
     // First determine if file exists in s3
     s3.headObject(params, (function(error, meta) {
         if (error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-backup-to-s3",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": "Dylan Lingelbach (https://github.com/dylanlingelbach)",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
Simply added 2 S3 options:
- ACL management (only for backup), that defines object ACL. In my case, the target S3 bucket owner is different from the account from which DynamoDB tables are, that's why I need to specify `bucket-owner-full-control`: https://stackoverflow.com/a/46076497/3263033
- ServerSideEncryption (for backup and restore): A S3 option that force encryption on S3, which can be useful for backups