### PR TITLE
Fix read capacity calculation and wait between scans

### DIFF
--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -159,38 +159,59 @@ DynamoBackup.prototype._copyTable = function (tableName, itemsReceived, callback
             return callback(err);
         }
 
-        var readPercentage = self.readPercentage;
-        var limit = Math.max((data.Table.ProvisionedThroughput.ReadCapacityUnits * readPercentage) | 0, 1);
+        const Table = data.Table;
+        var maxCapacityUnits = Math.max(Math.floor(Table.ProvisionedThroughput.ReadCapacityUnits * self.readPercentage), 1);
+        var averageItemSize = Table.TableSizeBytes / Table.ItemCount;
 
-        self._streamItems(tableName, null, limit, itemsReceived, callback);
+        self._streamItems(tableName, null, 0, maxCapacityUnits, averageItemSize, itemsReceived, callback);
     });
 };
 
-DynamoBackup.prototype._streamItems = function fetchItems(tableName, startKey, limit, itemsReceived, callback) {
+DynamoBackup.prototype._streamItems = function fetchItems(tableName, startKey, remainingCapacityUnits, maxCapacityUnits, averageItemSize, itemsReceived, callback) {
     var self = this;
     var ddb = new AWS.DynamoDB();
-    var params = {
-        Limit: limit,
-        ReturnConsumedCapacity: 'NONE',
-        TableName: tableName
-    };
-    if (startKey) {
-        params.ExclusiveStartKey = startKey;
+    var startOfSecond = new Date().getTime();
+    
+    var usableCapacity = maxCapacityUnits + remainingCapacityUnits;
+    if (usableCapacity > 0) {
+        var limit = Math.max(Math.floor(((8 * 1024) / averageItemSize) * usableCapacity), 1);
+        var params = {
+            Limit: limit,
+            ReturnConsumedCapacity: 'TOTAL',
+            TableName: tableName
+        };
+
+        if (startKey) {
+            params.ExclusiveStartKey = startKey;
+        }
+
+        ddb.scan(params, function (error, data) {
+            if (error) {
+                callback(error);
+                return;
+            }
+
+            if (data.Items.length > 0) {
+                itemsReceived(data.Items);
+            }
+
+            if (!data.LastEvaluatedKey || _.keys(data.LastEvaluatedKey).length === 0) {
+                callback();
+                return;
+            }
+
+            var nextRemainingCapacity = usableCapacity - data.ConsumedCapacity.CapacityUnits;
+            var timeout = Math.max(1000 - (new Date().getTime() - startOfSecond), 0);
+            setTimeout(function () {
+                self._streamItems(tableName, data.LastEvaluatedKey, nextRemainingCapacity, maxCapacityUnits, averageItemSize, itemsReceived, callback);
+            }, timeout);
+        });
+    } else {
+        // Wait until we have capacity again
+        setTimeout(() => {
+            self._streamItems(tableName, startKey, usableCapacity, maxCapacityUnits, averageItemSize, itemsReceived, callback);
+        }, 1000);
     }
-    ddb.scan(params, function (err, data) {
-        if (err) {
-            return callback(err);
-        }
-
-        if (data.Items.length > 0) {
-            itemsReceived(data.Items);
-        }
-
-        if (!data.LastEvaluatedKey || _.keys(data.LastEvaluatedKey).length === 0) {
-            return callback();
-        }
-        self._streamItems(tableName, data.LastEvaluatedKey, limit, itemsReceived, callback);
-    });
 };
 
 DynamoBackup.prototype._fetchTables = function (lastTable, tables, callback) {


### PR DESCRIPTION
Related to #60 

The current implementation of the usable read capacity has some issues and might lead to provisioned throughput exceptions.

The current implementation has two problems:

- All items are treated as units of 8kb, although some items might be smaller or larger than 8kb. This leads to problems especially where items are larger than 8kb.
- The current read capacity limit is effectively ignored, since the limit has a small impact on a single request, but there is no waiting period between requests. Therefore, the current implementation is solely bound by the available resources (most likely network) and is theoretically able to perform a full table backup within one second. Provisioned read capacity is however limited to a single second, therefore the new implementation will now wait until enough capacity is available again to proceed to the next scan request.

The new implementation solves these issues and will no longer exceed the requested limit. Exceptions to this case are tables that have a very low provisioned read capacity (e.g. 1), where the percentage limit has little effect and will result in an average consumption of 1 read capacity.

Backups might now take longer, but at least they respect the given read capacity.