### PR TITLE
Fix race condition which leads to corrupt or incomplete backups.

### DIFF
--- a/lib/readable-stream.js
+++ b/lib/readable-stream.js
@@ -21,7 +21,7 @@ ReadableStream.prototype._read = function(n) {
 };
 
 ReadableStream.prototype.append = function(data) {
-  this._data = data;
+  this._data += data;
   this.read(0);
 };
 


### PR DESCRIPTION
Sometimes the uploaded S3 backup of a table is missing data, which leads to a corrupted or incomplete backup.

The reason for this is that `stream.read(0)` in readable-stream.js is not always leading to an immediate `_read(n)` call by the stream.

If append is called multiple times, the `data` property is replaced completely, which leads to missing data in the stream.

This PR fixes this, by appending to the internal `data` property instead.