### PR TITLE
DYNAMO_CHUNK_SIZE multiple bug fix

### DIFF
--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -145,10 +145,12 @@ DynamoRestore.prototype._startDownload = function() {
             .on('line', this._processLine.bind(this))
             .on('close', (function() {
                 this.emit('finish-download');
-                this.batches.push({
-                    items: this.requestItems.splice(0, DYNAMO_CHUNK_SIZE),
-                    attempts: 0
-                });
+                if (this.requestItems.length) {
+                    this.batches.push({
+                        items: this.requestItems.splice(0, DYNAMO_CHUNK_SIZE),
+                        attempts: 0
+                    });
+                }
                 this._finishBatches();
             }).bind(this));
         this.readline.meta = meta;


### PR DESCRIPTION
Restoring fails if the json contains a number of records which is an exact multiple of DYNAMO_CHUNK_SIZE, because the download "close" contains no records but it was assumed it did. This created an empty batch. Added a check to only create the final batch if there actually were records in the close.