### PR TITLE
Fix for Global table replication Issue #80

### DIFF
--- a/bin/dynamo-backup-to-s3
+++ b/bin/dynamo-backup-to-s3
@@ -29,6 +29,7 @@ program
     .option('--aws-key <key>', 'AWS access key. Will use AWS_ACCESS_KEY_ID env var if --aws-key not set')
     .option('--aws-secret <secret>', 'AWS secret key. Will use AWS_SECRET_ACCESS_KEY env var if --aws-secret not set')
     .option('--aws-region <region>', 'AWS region. Will use AWS_DEFAULT_REGION env var if --aws-region not set')
+    .option('--strip-fields <list>', 'Won't include fields in the bakup', list)
     .parse(process.argv);
 
 // run program
@@ -46,8 +47,10 @@ var dynamoBackup = new DynamoBackup({
     readPercentage: program.readPercentage,
     stopOnFailure: program.stopOnFailure,
     base64Binary: program.base64EncodeBinary,
+    stripFields: program.stripFields,
     saveDataPipelineFormat: program.saveDataPipelineFormat
 });
+
 
 dynamoBackup.on('error', function(data) {
     console.log('Error backing up ' + data.tableName);
@@ -68,7 +71,13 @@ dynamoBackup.on('end-backup', function(tableName) {
     console.log('Done copying table ' + tableName + '. Took ' + endTime.diff(startTime, 'minutes', true).toFixed(2) + ' minutes');
 });
 
-dynamoBackup.backupAllTables(function() {
-    console.log('Finished backing up DynamoDB');
+dynamoBackup.backupAllTables(function(err) {
+    if(err){
+        console.log("Error "+ err);
+    }
+    else{
+      console.log('Finished backing up DynamoDB');
+    }
     process.exit(0);
 });
+

--- a/bin/dynamo-backup-to-s3
+++ b/bin/dynamo-backup-to-s3
@@ -29,7 +29,8 @@ program
     .option('--aws-key <key>', 'AWS access key. Will use AWS_ACCESS_KEY_ID env var if --aws-key not set')
     .option('--aws-secret <secret>', 'AWS secret key. Will use AWS_SECRET_ACCESS_KEY env var if --aws-secret not set')
     .option('--aws-region <region>', 'AWS region. Will use AWS_DEFAULT_REGION env var if --aws-region not set')
-    .option('--strip-fields <list>', 'Won't include fields in the bakup', list)
+    .option('--strip-fields <list>', 'exclue these fields in the bakup', list)
+    .option('-g, --global-table', 'specify if global table, will strip aws fields from backup')
     .parse(process.argv);
 
 // run program
@@ -48,6 +49,7 @@ var dynamoBackup = new DynamoBackup({
     stopOnFailure: program.stopOnFailure,
     base64Binary: program.base64EncodeBinary,
     stripFields: program.stripFields,
+    globalTable: program.globalTable,
     saveDataPipelineFormat: program.saveDataPipelineFormat
 });
 

--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -27,6 +27,12 @@ function DynamoBackup(options) {
     this.awsRegion = options.awsRegion;
     this.debug = Boolean(options.debug);
     this.stripFields = options.stripFields || [];
+    this.globalTable = options.globalTable || false;
+
+    if(this.globalTable){
+        var awsFields = ['aws:rep:updateregion', 'aws:rep:deleting', 'aws:rep:updatetime'];
+        this.stripFields = _.union(awsFields, this.stripFields);
+    }
 
     if (this.awsRegion) {
         params.region = this.awsRegion;

--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -56,7 +56,6 @@ DynamoBackup.prototype.backupTable = function (tableName, backupPath, callback) 
     var self = this;
     var stream = new ReadableStream();
 
-    console.log("starting backup for "+tableName);
     if (callback === undefined) {
         callback = backupPath;
         backupPath = self._getBackupPath();

--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -26,6 +26,7 @@ function DynamoBackup(options) {
     this.awsSecretKey = options.awsSecretKey;
     this.awsRegion = options.awsRegion;
     this.debug = Boolean(options.debug);
+    this.stripFields = options.stripFields || [];
 
     if (this.awsRegion) {
         params.region = this.awsRegion;
@@ -49,6 +50,7 @@ DynamoBackup.prototype.backupTable = function (tableName, backupPath, callback) 
     var self = this;
     var stream = new ReadableStream();
 
+    console.log("starting backup for "+tableName);
     if (callback === undefined) {
         callback = backupPath;
         backupPath = self._getBackupPath();
@@ -89,7 +91,12 @@ DynamoBackup.prototype.backupTable = function (tableName, backupPath, callback) 
         tableName,
         function (items) {
             items.forEach(function (item) {
-                if (self.base64Binary) {
+        	
+                 self.stripFields.forEach(function(key) {
+                     delete item[key]
+		 });
+		
+	        if (self.base64Binary) {
                     _.each(item, function (value, key) {
                         if (value && value.B) {
                             value.B = new Buffer(value.B).toString('base64');


### PR DESCRIPTION
Added option to strip some fields while taking backup.
using this to strip internal fields managed by aws for global table replication.

without this restoring backup on global table does not replicate items.
