### PR TITLE
Add dynamo-restore-from-s3 script to bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "stream"
   ],
   "bin": {
-    "dynamo-backup-to-s3": "./bin/dynamo-backup-to-s3"
+    "dynamo-backup-to-s3": "./bin/dynamo-backup-to-s3",
+    "dynamo-restore-from-s3": "./bin/dynamo-restore-from-s3"
   },
   "dependencies": {
     "async": "^1.5.0",


### PR DESCRIPTION
Since `dynamo-restore-from-s3` is missing in the `bin` section of `package.json`, `dynamo-restore-from-s3` command is not found on global npm package installation. Adding it fixes the issue.